### PR TITLE
Move USB keyboard and mouse group to kvm

### DIFF
--- a/modules/users/accounts.nix
+++ b/modules/users/accounts.nix
@@ -32,13 +32,6 @@ in
 
     config = mkIf cfg.enable {
       users = {
-        # User microvm needs an access to the USB devices such as input devices.
-        # Those devices are owned by root in ghaf system.
-        # The proper way of fixing that is creating a Udev rule which assigns
-        # usb devices to the specific group and add microvm and ghaf users to
-        # that group, but I do not have an idea on how to implement that in a
-        # nice and correct way, so I leave it as is for now.
-        groups.root.members = ["microvm"];
         mutableUsers = true;
         users."${cfg.user}" = {
           isNormalUser = true;

--- a/targets/generic-x86_64.nix
+++ b/targets/generic-x86_64.nix
@@ -86,6 +86,8 @@
                 debug.enable = variant == "debug";
               };
             };
+            # Group kvm needs to access to USB keyboard and mouse for guivm USB passthrough 
+            services.udev.extraRules= "SUBSYSTEM==\"usb\",ATTR{idVendor}==\"046d\",ATTR{idProduct}==\"c534\",GROUP+=\"kvm\"";
           }
 
           formatModule


### PR DESCRIPTION
The root group permission to microvm is removed and kvm group permission added for the USB keyboard/mouse device to udev rules.